### PR TITLE
feat: JsonPointerRepository — store JSON documents as per-pointer DynamoDB items

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.github/workflows/*.lock.yml linguist-generated=true merge=ours

--- a/JSON_POINTER_REPOSITORY.md
+++ b/JSON_POINTER_REPOSITORY.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-A specialisation of `DynamoDbRepository` that stores JSON documents as individual attribute-per-item rows, addressed by JSON Pointer (RFC 6901). Each DynamoDB item represents a single leaf value of a JSON document:
+A specialisation of `DynamoDbRepository` that stores JSON documents as individual attribute-per-item rows, addressed by JSON Pointer (RFC 6901). Each DynamoDB item represents a single leaf value of a JSON document.
+
+Only **JSON objects** are supported as the root document (the class is typed `T extends Record<string, unknown>`). Documents must contain at least one leaf value; empty objects and empty arrays are not supported.
 
 | Attribute | Role | Example |
 |-----------|------|---------|
@@ -23,24 +25,22 @@ A full document is reconstructed by fetching all items sharing the same `id` and
 
 ## Class Design
 
+`JsonPointerRepository<T>` uses **composition** — it wraps an internal `DynamoDbRepository` instance rather than extending it.
+
 ```ts
-class JsonPointerRepository<T> extends DynamoDbRepository<JsonPointerKey, JsonPointerItem>
+class JsonPointerRepository<T extends Record<string, unknown>>
 ```
 
+`JsonPointerRepositoryOptions` is a standalone interface (not an extension of `DynamoDbRepositoryOptions`):
+
 ```ts
-interface JsonPointerKey {
-    id: string;
-    pointer: string;
-}
-
-interface JsonPointerItem extends JsonPointerKey {
-    value: unknown;
-}
-
-interface JsonPointerRepositoryOptions extends DynamoDbRepositoryOptions {
+interface JsonPointerRepositoryOptions {
+    client: DynamoDBClient;
+    tableName: string;
     idKey?: string;       // default: "id"
     pointerKey?: string;  // default: "pointer"
     valueKey?: string;    // default: "value"
+    returnConsumedCapacity?: ReturnConsumedCapacity;
 }
 ```
 
@@ -57,8 +57,8 @@ Reads all items for `id` and reconstructs the JSON document from pointer/value p
 ### `getAttribute<V>(id: string, pointer: string): Promise<V | undefined>`
 Reads the single item at `(id, pointer)` and returns its value.
 
-### `putAttribute<V>(id: string, pointer: string, value: V): Promise<void>`
-Writes a single pointer/value item. Creates or replaces.
+### `putAttribute(id: string, pointer: string, value: JsonPointerValue): Promise<void>`
+Writes a single pointer/value item. Creates or replaces. `pointer` must start with `"/"`.
 
 ### `deleteAttribute(id: string, pointer: string): Promise<void>`
 Deletes the item at `(id, pointer)`.

--- a/JSON_POINTER_REPOSITORY.md
+++ b/JSON_POINTER_REPOSITORY.md
@@ -1,0 +1,106 @@
+# JSON Pointer Repository
+
+## Overview
+
+A specialisation of `DynamoDbRepository` that stores JSON documents as individual attribute-per-item rows, addressed by JSON Pointer (RFC 6901). Each DynamoDB item represents a single leaf value of a JSON document:
+
+| Attribute | Role | Example |
+|-----------|------|---------|
+| `id` | Hash key — identifies the document | `"user-123"` |
+| `pointer` | Range key — JSON Pointer path to the value | `"/address/city"` |
+| `value` | The leaf value at that pointer | `"Melbourne"` |
+
+A full document is reconstructed by fetching all items sharing the same `id` and reassembling the pointer/value pairs.
+
+---
+
+## DynamoDB Table Requirements
+
+- **Hash key**: `id` (String)
+- **Range key**: `pointer` (String)
+
+---
+
+## Class Design
+
+```ts
+class JsonPointerRepository<T> extends DynamoDbRepository<JsonPointerKey, JsonPointerItem>
+```
+
+```ts
+interface JsonPointerKey {
+    id: string;
+    pointer: string;
+}
+
+interface JsonPointerItem extends JsonPointerKey {
+    value: unknown;
+}
+
+interface JsonPointerRepositoryOptions extends DynamoDbRepositoryOptions {
+    idKey?: string;       // default: "id"
+    pointerKey?: string;  // default: "pointer"
+    valueKey?: string;    // default: "value"
+}
+```
+
+---
+
+## Methods
+
+### `putDocument(id: string, document: T): Promise<void>`
+Flattens `document` into pointer/value pairs and writes each as a DynamoDB item. Replaces any existing items for that `id`.
+
+### `getDocument(id: string): Promise<T | undefined>`
+Reads all items for `id` and reconstructs the JSON document from pointer/value pairs.
+
+### `getAttribute<V>(id: string, pointer: string): Promise<V | undefined>`
+Reads the single item at `(id, pointer)` and returns its value.
+
+### `putAttribute<V>(id: string, pointer: string, value: V): Promise<void>`
+Writes a single pointer/value item. Creates or replaces.
+
+### `deleteAttribute(id: string, pointer: string): Promise<void>`
+Deletes the item at `(id, pointer)`.
+
+### `deleteDocument(id: string): Promise<void>`
+Deletes all items belonging to a document (all range key entries for a given `id`).
+
+### ~~`queryDocumentsByAttribute<V>(pointer: string, value: V): Promise<T[]>`~~
+Removed from scope.
+
+---
+
+## Flattening Rules
+
+- Only **leaf nodes** (primitives: string, number, boolean, null) are stored as individual items.
+- **Arrays** are flattened with index-based pointers: `/tags/0`, `/tags/1`.
+- **Nested objects** are recursively flattened: `/address/city`, `/address/postcode`.
+- The root pointer `/` is not stored; only fully-qualified leaf paths are.
+
+**Example** — document:
+```json
+{ "name": "Alice", "address": { "city": "Melbourne" }, "tags": ["a", "b"] }
+```
+Stored as:
+| id | pointer | value |
+|----|---------|-------|
+| `user-123` | `/name` | `"Alice"` |
+| `user-123` | `/address/city` | `"Melbourne"` |
+| `user-123` | `/tags/0` | `"a"` |
+| `user-123` | `/tags/1` | `"b"` |
+
+---
+
+## Dependencies
+
+- No new runtime dependencies — implement flattening/reconstruction internally using RFC 6901 pointer logic.
+- Reuse `DynamoDbRepository` for all DynamoDB interactions.
+
+---
+
+## Decisions
+
+- `putDocument` **will** delete stale pointers (fetch existing pointers first, delete any not present in the new document).
+- `value` type is constrained to `string | number | boolean | null`.
+- `queryDocumentsByAttribute` is **out of scope**.

--- a/src/JsonPointerRepository.ts
+++ b/src/JsonPointerRepository.ts
@@ -1,0 +1,179 @@
+import { DynamoDBClient, ReturnConsumedCapacity } from "@aws-sdk/client-dynamodb";
+import { DynamoDbRepository } from "./DynamoDbRepository";
+
+export type JsonPointerValue = string | number | boolean | null;
+
+export interface JsonPointerRepositoryOptions {
+    client: DynamoDBClient;
+    tableName: string;
+    idKey?: string;
+    pointerKey?: string;
+    valueKey?: string;
+    returnConsumedCapacity?: ReturnConsumedCapacity;
+}
+
+type PointerKey = Record<string, string>;
+type PointerItem = Record<string, unknown>;
+
+const escapeToken = (token: string): string =>
+    token.replace(/~/g, "~0").replace(/\//g, "~1");
+
+const unescapeToken = (token: string): string =>
+    token.replace(/~1/g, "/").replace(/~0/g, "~");
+
+const flattenDocument = (doc: unknown, prefix = ""): Record<string, JsonPointerValue> => {
+    if (doc === null) return { [prefix]: null };
+    if (typeof doc !== "object") return { [prefix]: doc as JsonPointerValue };
+
+    const result: Record<string, JsonPointerValue> = {};
+
+    if (Array.isArray(doc)) {
+        for (let i = 0; i < doc.length; i++) {
+            Object.assign(result, flattenDocument(doc[i], `${prefix}/${i}`));
+        }
+    } else {
+        for (const [key, value] of Object.entries(doc)) {
+            Object.assign(result, flattenDocument(value, `${prefix}/${escapeToken(key)}`));
+        }
+    }
+
+    return result;
+};
+
+const setAtPointer = (
+    root: Record<string, unknown>,
+    pointer: string,
+    value: JsonPointerValue,
+): void => {
+    const tokens = pointer.split("/").slice(1).map(unescapeToken);
+    if (tokens.length === 0) return;
+
+    let current: Record<string, unknown> = root;
+    for (let i = 0; i < tokens.length - 1; i++) {
+        const token = tokens[i];
+        const nextToken = tokens[i + 1];
+        if (current[token] == null) {
+            current[token] = /^\d+$/.test(nextToken) ? [] : {};
+        }
+        current = current[token] as Record<string, unknown>;
+    }
+
+    const lastToken = tokens[tokens.length - 1];
+    current[lastToken] = value;
+};
+
+const reconstructDocument = <T>(
+    items: Array<{ pointer: string; value: JsonPointerValue }>,
+): T => {
+    const root: Record<string, unknown> = {};
+    const sorted = [...items].sort((a, b) => a.pointer.localeCompare(b.pointer));
+    for (const item of sorted) {
+        setAtPointer(root, item.pointer, item.value);
+    }
+    return root as T;
+};
+
+export class JsonPointerRepository<T extends Record<string, unknown>> {
+    private readonly repository: DynamoDbRepository<PointerKey, PointerItem>;
+    private readonly idKey: string;
+    private readonly pointerKey: string;
+    private readonly valueKey: string;
+
+    constructor(options: JsonPointerRepositoryOptions) {
+        const {
+            client,
+            tableName,
+            idKey = "id",
+            pointerKey = "pointer",
+            valueKey = "value",
+            returnConsumedCapacity,
+        } = options;
+
+        this.idKey = idKey;
+        this.pointerKey = pointerKey;
+        this.valueKey = valueKey;
+
+        this.repository = new DynamoDbRepository<PointerKey, PointerItem>({
+            client,
+            tableName,
+            hashKey: idKey,
+            rangeKey: pointerKey,
+            returnConsumedCapacity,
+        });
+    }
+
+    putDocument = async (id: string, document: T): Promise<void> => {
+        const flat = flattenDocument(document);
+        const newPointers = Object.keys(flat);
+
+        const existing = await this.repository.getItems({ [this.idKey]: id }) ?? [];
+        const existingPointers = existing.map(item => item[this.pointerKey] as string);
+        const stalePointers = existingPointers.filter(p => !newPointers.includes(p));
+
+        await Promise.all([
+            ...stalePointers.map(pointer =>
+                this.repository.deleteItem({
+                    [this.idKey]: id,
+                    [this.pointerKey]: pointer,
+                } as PointerKey),
+            ),
+            ...Object.entries(flat).map(([pointer, value]) =>
+                this.repository.putItem(
+                    { [this.idKey]: id, [this.pointerKey]: pointer } as PointerKey,
+                    { [this.idKey]: id, [this.pointerKey]: pointer, [this.valueKey]: value } as PointerItem,
+                ),
+            ),
+        ]);
+    };
+
+    getDocument = async (id: string): Promise<T | undefined> => {
+        const items = await this.repository.getItems({ [this.idKey]: id });
+        if (!items || items.length === 0) return undefined;
+
+        return reconstructDocument<T>(
+            items.map(item => ({
+                pointer: item[this.pointerKey] as string,
+                value: item[this.valueKey] as JsonPointerValue,
+            })),
+        );
+    };
+
+    getAttribute = async <V = JsonPointerValue>(
+        id: string,
+        pointer: string,
+    ): Promise<V | undefined> => {
+        const item = await this.repository.getItem({
+            [this.idKey]: id,
+            [this.pointerKey]: pointer,
+        } as PointerKey);
+        return item ? (item[this.valueKey] as V) : undefined;
+    };
+
+    putAttribute = async (
+        id: string,
+        pointer: string,
+        value: JsonPointerValue,
+    ): Promise<void> => {
+        const key = { [this.idKey]: id, [this.pointerKey]: pointer } as PointerKey;
+        await this.repository.putItem(key, { ...key, [this.valueKey]: value } as PointerItem);
+    };
+
+    deleteAttribute = async (id: string, pointer: string): Promise<void> => {
+        await this.repository.deleteItem({
+            [this.idKey]: id,
+            [this.pointerKey]: pointer,
+        } as PointerKey);
+    };
+
+    deleteDocument = async (id: string): Promise<void> => {
+        const items = await this.repository.getItems({ [this.idKey]: id }) ?? [];
+        await Promise.all(
+            items.map(item =>
+                this.repository.deleteItem({
+                    [this.idKey]: id,
+                    [this.pointerKey]: item[this.pointerKey] as string,
+                } as PointerKey),
+            ),
+        );
+    };
+}

--- a/src/JsonPointerRepository.ts
+++ b/src/JsonPointerRepository.ts
@@ -15,15 +15,35 @@ export interface JsonPointerRepositoryOptions {
 type PointerKey = Record<string, string>;
 type PointerItem = Record<string, unknown>;
 
+const isJsonPointerValue = (value: unknown): value is JsonPointerValue =>
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean";
+
 const escapeToken = (token: string): string =>
     token.replace(/~/g, "~0").replace(/\//g, "~1");
 
 const unescapeToken = (token: string): string =>
     token.replace(/~1/g, "/").replace(/~0/g, "~");
 
+const validatePointer = (pointer: string): void => {
+    if (!pointer.startsWith("/")) {
+        throw new TypeError(`Invalid JSON Pointer "${pointer}": must start with "/".`);
+    }
+};
+
 const flattenDocument = (doc: unknown, prefix = ""): Record<string, JsonPointerValue> => {
     if (doc === null) return { [prefix]: null };
-    if (typeof doc !== "object") return { [prefix]: doc as JsonPointerValue };
+    if (typeof doc !== "object") {
+        if (isJsonPointerValue(doc)) {
+            return { [prefix]: doc };
+        }
+        const pointer = prefix === "" ? "/" : prefix;
+        throw new TypeError(
+            `Unsupported value at JSON pointer "${pointer}": expected string, number, boolean, or null but received ${typeof doc}.`,
+        );
+    }
 
     const result: Record<string, JsonPointerValue> = {};
 
@@ -54,6 +74,10 @@ const setAtPointer = (
         const nextToken = tokens[i + 1];
         if (current[token] == null) {
             current[token] = /^\d+$/.test(nextToken) ? [] : {};
+        } else if (typeof current[token] !== "object") {
+            throw new TypeError(
+                `Conflicting pointers: cannot traverse "${pointer}" because "/${tokens.slice(0, i + 1).join("/")}" already holds a primitive value.`,
+            );
         }
         current = current[token] as Record<string, unknown>;
     }
@@ -73,6 +97,13 @@ const reconstructDocument = <T>(
     return root as T;
 };
 
+/**
+ * Stores JSON documents as individual per-pointer DynamoDB items addressed by JSON Pointer (RFC 6901).
+ *
+ * Only JSON objects are supported as the root document (`T extends Record<string, unknown>`).
+ * Root arrays and primitives are not supported. Documents must contain at least one leaf value;
+ * empty objects and empty arrays are not supported.
+ */
 export class JsonPointerRepository<T extends Record<string, unknown>> {
     private readonly repository: DynamoDbRepository<PointerKey, PointerItem>;
     private readonly idKey: string;
@@ -106,9 +137,16 @@ export class JsonPointerRepository<T extends Record<string, unknown>> {
         const flat = flattenDocument(document);
         const newPointers = Object.keys(flat);
 
+        if (newPointers.length === 0) {
+            throw new TypeError(
+                "Cannot store a document with no leaf values. Empty objects and arrays are not supported.",
+            );
+        }
+
+        const newPointerSet = new Set(newPointers);
         const existing = await this.repository.getItems({ [this.idKey]: id }) ?? [];
         const existingPointers = existing.map(item => item[this.pointerKey] as string);
-        const stalePointers = existingPointers.filter(p => !newPointers.includes(p));
+        const stalePointers = existingPointers.filter(p => !newPointerSet.has(p));
 
         await Promise.all([
             ...stalePointers.map(pointer =>
@@ -142,6 +180,7 @@ export class JsonPointerRepository<T extends Record<string, unknown>> {
         id: string,
         pointer: string,
     ): Promise<V | undefined> => {
+        validatePointer(pointer);
         const item = await this.repository.getItem({
             [this.idKey]: id,
             [this.pointerKey]: pointer,
@@ -154,11 +193,13 @@ export class JsonPointerRepository<T extends Record<string, unknown>> {
         pointer: string,
         value: JsonPointerValue,
     ): Promise<void> => {
+        validatePointer(pointer);
         const key = { [this.idKey]: id, [this.pointerKey]: pointer } as PointerKey;
         await this.repository.putItem(key, { ...key, [this.valueKey]: value } as PointerItem);
     };
 
     deleteAttribute = async (id: string, pointer: string): Promise<void> => {
+        validatePointer(pointer);
         await this.repository.deleteItem({
             [this.idKey]: id,
             [this.pointerKey]: pointer,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export {type Query, type IndexedQuery, type ProjectedQuery, type FilterableQuery, type FilterExpression, FilterOperator, DynamoDbRepository, type DynamoDbRepositoryOptions} from "./DynamoDbRepository";
-export {consumedCapacityMiddleware, type ConsumedCapacityDetail, type ConsumedCapacityMiddlewareConfig} from "./consumed-capacity-middleware"
+export {consumedCapacityMiddleware, type ConsumedCapacityDetail, type ConsumedCapacityMiddlewareConfig} from "./consumed-capacity-middleware";
+export {JsonPointerRepository, type JsonPointerRepositoryOptions, type JsonPointerValue} from "./JsonPointerRepository";
 
 

--- a/test/DynamoDbRepository.test.ts
+++ b/test/DynamoDbRepository.test.ts
@@ -1,5 +1,5 @@
 
-import { DynamoDBClient, CreateTableCommand, DescribeTableCommand, PutItemCommand } from "@aws-sdk/client-dynamodb";
+import { DynamoDBClient, CreateTableCommand, DescribeTableCommand, PutItemCommand, type DynamoDBClientConfig } from "@aws-sdk/client-dynamodb";
 import { marshall } from "@aws-sdk/util-dynamodb";
 import { GenericContainer, StartedTestContainer } from "testcontainers";
 import {ConsumedCapacityDetail, consumedCapacityMiddleware, DynamoDbRepository, FilterOperator} from "../src";
@@ -33,14 +33,12 @@ describe('DynamoDbRepository Integration Tests', () => {
             .start();
 
         // Create DynamoDB client pointing to the container
-        dynamoDBClient = new DynamoDBClient({
+        const clientConfig: DynamoDBClientConfig = {
             endpoint: `http://${container.getHost()}:${container.getMappedPort(8000)}`,
             region: "us-east-1",
-            credentials: {
-                accessKeyId: "test",
-                secretAccessKey: "test",
-            },
-        });
+            credentials: async () => ({ accessKeyId: "test", secretAccessKey: "test" }),
+        };
+        dynamoDBClient = new (DynamoDBClient as unknown as new (config: DynamoDBClientConfig) => DynamoDBClient)(clientConfig);
 
         dynamoDBClient.middlewareStack
             .add(consumedCapacityMiddleware({onConsumedCapacity: async (consumedCapacity) =>

--- a/test/JsonPointerRepository.test.ts
+++ b/test/JsonPointerRepository.test.ts
@@ -282,6 +282,59 @@ describe("JsonPointerRepository Integration Tests", () => {
         });
     });
 
+    // ─── validation ──────────────────────────────────────────────────────────
+
+    describe("validation", () => {
+        it("throws TypeError for an unsupported leaf type (function)", async () => {
+            const doc = { fn: () => "oops" } as unknown as TestDocument;
+            await expect(repository.putDocument("invalid-type", doc)).rejects.toThrow(TypeError);
+        });
+
+        it("throws TypeError for an unsupported leaf type (bigint)", async () => {
+            const doc = { n: BigInt(42) } as unknown as TestDocument;
+            await expect(repository.putDocument("invalid-bigint", doc)).rejects.toThrow(TypeError);
+        });
+
+        it("throws TypeError when storing an empty document", async () => {
+            await expect(repository.putDocument("empty-doc", {} as TestDocument)).rejects.toThrow(
+                "Cannot store a document with no leaf values",
+            );
+        });
+
+        it("throws TypeError when storing a document with only empty containers", async () => {
+            const doc = { nested: {} } as TestDocument;
+            await expect(repository.putDocument("empty-nested", doc)).rejects.toThrow(
+                "Cannot store a document with no leaf values",
+            );
+        });
+
+        it("throws TypeError for getAttribute with a pointer not starting with '/'", async () => {
+            await expect(repository.getAttribute("any-doc", "name")).rejects.toThrow(
+                'Invalid JSON Pointer "name"',
+            );
+        });
+
+        it("throws TypeError for putAttribute with a pointer not starting with '/'", async () => {
+            await expect(repository.putAttribute("any-doc", "name", "value")).rejects.toThrow(
+                'Invalid JSON Pointer "name"',
+            );
+        });
+
+        it("throws TypeError for deleteAttribute with a pointer not starting with '/'", async () => {
+            await expect(repository.deleteAttribute("any-doc", "name")).rejects.toThrow(
+                'Invalid JSON Pointer "name"',
+            );
+        });
+
+        it("throws TypeError on getDocument when conflicting pointers are present", async () => {
+            await repository.putAttribute("conflict-doc", "/a", "leaf");
+            await repository.putAttribute("conflict-doc", "/a/b", "nested");
+            await expect(repository.getDocument("conflict-doc")).rejects.toThrow(
+                "Conflicting pointers",
+            );
+        });
+    });
+
     // ─── custom key names ────────────────────────────────────────────────────
 
     describe("custom key names", () => {

--- a/test/JsonPointerRepository.test.ts
+++ b/test/JsonPointerRepository.test.ts
@@ -1,0 +1,342 @@
+import {
+    CreateTableCommand,
+    DescribeTableCommand,
+    DynamoDBClient,
+    type DynamoDBClientConfig,
+} from "@aws-sdk/client-dynamodb";
+import { GenericContainer, StartedTestContainer } from "testcontainers";
+import { JsonPointerRepository } from "../src";
+
+type TestDocument = Record<string, unknown>;
+
+describe("JsonPointerRepository Integration Tests", () => {
+    let container: StartedTestContainer;
+    let dynamoDBClient: DynamoDBClient;
+    let repository: JsonPointerRepository<TestDocument>;
+
+    const tableName = "json-pointer-test-table";
+
+    beforeAll(async () => {
+        container = await new GenericContainer("amazon/dynamodb-local")
+            .withExposedPorts(8000)
+            .start();
+
+        const clientConfig: DynamoDBClientConfig = {
+            endpoint: `http://${container.getHost()}:${container.getMappedPort(8000)}`,
+            region: "us-east-1",
+            credentials: async () => ({ accessKeyId: "test", secretAccessKey: "test" }),
+        };
+        dynamoDBClient = new (DynamoDBClient as unknown as new (config: DynamoDBClientConfig) => DynamoDBClient)(clientConfig);
+
+        await dynamoDBClient.send(
+            new CreateTableCommand({
+                TableName: tableName,
+                KeySchema: [
+                    { AttributeName: "id", KeyType: "HASH" },
+                    { AttributeName: "pointer", KeyType: "RANGE" },
+                ],
+                AttributeDefinitions: [
+                    { AttributeName: "id", AttributeType: "S" },
+                    { AttributeName: "pointer", AttributeType: "S" },
+                ],
+                BillingMode: "PAY_PER_REQUEST",
+            }),
+        );
+
+        let active = false;
+        while (!active) {
+            const res = await dynamoDBClient.send(new DescribeTableCommand({ TableName: tableName }));
+            active = res.Table?.TableStatus === "ACTIVE";
+            if (!active) await new Promise(r => setTimeout(r, 100));
+        }
+
+        repository = new JsonPointerRepository<TestDocument>({
+            client: dynamoDBClient,
+            tableName,
+        });
+    });
+
+    afterAll(async () => {
+        dynamoDBClient?.destroy();
+        await container?.stop();
+    });
+
+    // ─── putDocument / getDocument ───────────────────────────────────────────
+
+    describe("putDocument / getDocument", () => {
+        it("returns undefined for a document that has never been stored", async () => {
+            const result = await repository.getDocument("does-not-exist");
+            expect(result).toBeUndefined();
+        });
+
+        it("round-trips a flat document", async () => {
+            const doc = { name: "Alice", age: 30, active: true };
+            await repository.putDocument("flat-1", doc);
+            expect(await repository.getDocument("flat-1")).toEqual(doc);
+        });
+
+        it("round-trips a document with a null value", async () => {
+            const doc = { name: "Bob", nickname: null };
+            await repository.putDocument("null-1", doc);
+            expect(await repository.getDocument("null-1")).toEqual(doc);
+        });
+
+        it("round-trips a deeply nested document", async () => {
+            const doc = {
+                user: {
+                    profile: {
+                        name: "Carol",
+                        address: { city: "Melbourne", postcode: "3000" },
+                    },
+                },
+            };
+            await repository.putDocument("nested-1", doc);
+            expect(await repository.getDocument("nested-1")).toEqual(doc);
+        });
+
+        it("round-trips a document containing an array", async () => {
+            const doc = { tags: ["alpha", "beta", "gamma"] };
+            await repository.putDocument("array-1", doc);
+            expect(await repository.getDocument("array-1")).toEqual(doc);
+        });
+
+        it("round-trips a document with an array of objects", async () => {
+            const doc = {
+                items: [
+                    { id: 1, label: "first" },
+                    { id: 2, label: "second" },
+                ],
+            };
+            await repository.putDocument("array-obj-1", doc);
+            expect(await repository.getDocument("array-obj-1")).toEqual(doc);
+        });
+
+        it("round-trips a document with keys containing special characters (/ and ~)", async () => {
+            const doc = { "a/b": "slash", "c~d": "tilde" };
+            await repository.putDocument("special-keys-1", doc);
+            expect(await repository.getDocument("special-keys-1")).toEqual(doc);
+        });
+
+        it("round-trips a document with number and boolean leaf values", async () => {
+            const doc = { count: 42, ratio: 3.14, enabled: false };
+            await repository.putDocument("types-1", doc);
+            expect(await repository.getDocument("types-1")).toEqual(doc);
+        });
+
+        it("overwrites an existing document with new content", async () => {
+            await repository.putDocument("overwrite-1", { name: "Old", value: 1 });
+            await repository.putDocument("overwrite-1", { name: "New", value: 2 });
+            expect(await repository.getDocument("overwrite-1")).toEqual({ name: "New", value: 2 });
+        });
+
+        it("deletes stale pointers when a key is removed from the document", async () => {
+            await repository.putDocument("stale-1", { keep: "yes", remove: "no" });
+            await repository.putDocument("stale-1", { keep: "yes" });
+            const result = await repository.getDocument("stale-1");
+            expect(result).toEqual({ keep: "yes" });
+            expect(result).not.toHaveProperty("remove");
+        });
+
+        it("deletes stale pointers when an array shrinks", async () => {
+            await repository.putDocument("stale-array-1", { tags: ["a", "b", "c"] });
+            await repository.putDocument("stale-array-1", { tags: ["a"] });
+            expect(await repository.getDocument("stale-array-1")).toEqual({ tags: ["a"] });
+        });
+
+        it("deletes stale pointers when nested keys are removed", async () => {
+            await repository.putDocument("stale-nested-1", { a: { x: 1, y: 2 } });
+            await repository.putDocument("stale-nested-1", { a: { x: 1 } });
+            expect(await repository.getDocument("stale-nested-1")).toEqual({ a: { x: 1 } });
+        });
+
+        it("replaces a string value with a number value at the same pointer", async () => {
+            await repository.putDocument("type-change-1", { score: "high" });
+            await repository.putDocument("type-change-1", { score: 99 });
+            expect(await repository.getDocument("type-change-1")).toEqual({ score: 99 });
+        });
+    });
+
+    // ─── getAttribute ────────────────────────────────────────────────────────
+
+    describe("getAttribute", () => {
+        beforeAll(async () => {
+            await repository.putDocument("get-attr-doc", {
+                name: "Dave",
+                address: { city: "Sydney" },
+                scores: [10, 20],
+            });
+        });
+
+        it("returns the value at a top-level pointer", async () => {
+            expect(await repository.getAttribute("get-attr-doc", "/name")).toBe("Dave");
+        });
+
+        it("returns the value at a nested pointer", async () => {
+            expect(await repository.getAttribute("get-attr-doc", "/address/city")).toBe("Sydney");
+        });
+
+        it("returns the value at an array index pointer", async () => {
+            expect(await repository.getAttribute("get-attr-doc", "/scores/0")).toBe(10);
+            expect(await repository.getAttribute("get-attr-doc", "/scores/1")).toBe(20);
+        });
+
+        it("returns undefined for a pointer that does not exist", async () => {
+            expect(await repository.getAttribute("get-attr-doc", "/nonexistent")).toBeUndefined();
+        });
+
+        it("returns undefined for a document that does not exist", async () => {
+            expect(await repository.getAttribute("no-such-doc", "/name")).toBeUndefined();
+        });
+    });
+
+    // ─── putAttribute ────────────────────────────────────────────────────────
+
+    describe("putAttribute", () => {
+        it("creates a new attribute on a document", async () => {
+            await repository.putDocument("put-attr-1", { existing: "value" });
+            await repository.putAttribute("put-attr-1", "/new", "added");
+            expect(await repository.getAttribute("put-attr-1", "/new")).toBe("added");
+        });
+
+        it("overwrites an existing attribute", async () => {
+            await repository.putDocument("put-attr-2", { name: "Before" });
+            await repository.putAttribute("put-attr-2", "/name", "After");
+            expect(await repository.getAttribute("put-attr-2", "/name")).toBe("After");
+        });
+
+        it("creates an attribute on a document that did not previously exist", async () => {
+            await repository.putAttribute("brand-new-doc", "/title", "Hello");
+            expect(await repository.getAttribute("brand-new-doc", "/title")).toBe("Hello");
+        });
+
+        it("stores a number attribute", async () => {
+            await repository.putAttribute("put-attr-num", "/count", 42);
+            expect(await repository.getAttribute("put-attr-num", "/count")).toBe(42);
+        });
+
+        it("stores a boolean attribute", async () => {
+            await repository.putAttribute("put-attr-bool", "/active", false);
+            expect(await repository.getAttribute("put-attr-bool", "/active")).toBe(false);
+        });
+
+        it("stores a null attribute", async () => {
+            await repository.putAttribute("put-attr-null", "/empty", null);
+            expect(await repository.getAttribute("put-attr-null", "/empty")).toBeNull();
+        });
+    });
+
+    // ─── deleteAttribute ─────────────────────────────────────────────────────
+
+    describe("deleteAttribute", () => {
+        it("removes a specific attribute from a document", async () => {
+            await repository.putDocument("del-attr-1", { keep: "yes", remove: "no" });
+            await repository.deleteAttribute("del-attr-1", "/remove");
+            expect(await repository.getAttribute("del-attr-1", "/remove")).toBeUndefined();
+            expect(await repository.getAttribute("del-attr-1", "/keep")).toBe("yes");
+        });
+
+        it("does not affect other documents when deleting an attribute", async () => {
+            await repository.putDocument("del-attr-2a", { name: "A" });
+            await repository.putDocument("del-attr-2b", { name: "B" });
+            await repository.deleteAttribute("del-attr-2a", "/name");
+            expect(await repository.getAttribute("del-attr-2b", "/name")).toBe("B");
+        });
+
+        it("is a no-op for a pointer that does not exist", async () => {
+            await repository.putDocument("del-attr-3", { name: "safe" });
+            await expect(
+                repository.deleteAttribute("del-attr-3", "/nonexistent"),
+            ).resolves.not.toThrow();
+            expect(await repository.getAttribute("del-attr-3", "/name")).toBe("safe");
+        });
+    });
+
+    // ─── deleteDocument ──────────────────────────────────────────────────────
+
+    describe("deleteDocument", () => {
+        it("removes all pointer items for a document", async () => {
+            await repository.putDocument("del-doc-1", { a: 1, b: { c: 2 } });
+            await repository.deleteDocument("del-doc-1");
+            expect(await repository.getDocument("del-doc-1")).toBeUndefined();
+        });
+
+        it("does not affect other documents", async () => {
+            await repository.putDocument("del-doc-2a", { name: "keep" });
+            await repository.putDocument("del-doc-2b", { name: "delete" });
+            await repository.deleteDocument("del-doc-2b");
+            expect(await repository.getDocument("del-doc-2a")).toEqual({ name: "keep" });
+        });
+
+        it("is a no-op for a document that does not exist", async () => {
+            await expect(repository.deleteDocument("no-such-doc-delete")).resolves.not.toThrow();
+        });
+
+        it("removes all items including nested and array pointers", async () => {
+            await repository.putDocument("del-doc-deep", {
+                name: "full",
+                tags: ["x", "y"],
+                meta: { created: "today" },
+            });
+            await repository.deleteDocument("del-doc-deep");
+            expect(await repository.getDocument("del-doc-deep")).toBeUndefined();
+        });
+    });
+
+    // ─── custom key names ────────────────────────────────────────────────────
+
+    describe("custom key names", () => {
+        let customRepo: JsonPointerRepository<TestDocument>;
+        const customTable = "json-pointer-custom-table";
+
+        beforeAll(async () => {
+            await dynamoDBClient.send(
+                new CreateTableCommand({
+                    TableName: customTable,
+                    KeySchema: [
+                        { AttributeName: "docId", KeyType: "HASH" },
+                        { AttributeName: "path", KeyType: "RANGE" },
+                    ],
+                    AttributeDefinitions: [
+                        { AttributeName: "docId", AttributeType: "S" },
+                        { AttributeName: "path", AttributeType: "S" },
+                    ],
+                    BillingMode: "PAY_PER_REQUEST",
+                }),
+            );
+
+            let active = false;
+            while (!active) {
+                const res = await dynamoDBClient.send(
+                    new DescribeTableCommand({ TableName: customTable }),
+                );
+                active = res.Table?.TableStatus === "ACTIVE";
+                if (!active) await new Promise(r => setTimeout(r, 100));
+            }
+
+            customRepo = new JsonPointerRepository<TestDocument>({
+                client: dynamoDBClient,
+                tableName: customTable,
+                idKey: "docId",
+                pointerKey: "path",
+                valueKey: "data",
+            });
+        });
+
+        it("stores and retrieves documents using custom key attribute names", async () => {
+            const doc = { title: "Custom", count: 7 };
+            await customRepo.putDocument("custom-doc-1", doc);
+            expect(await customRepo.getDocument("custom-doc-1")).toEqual(doc);
+        });
+
+        it("getAttribute works with custom key names", async () => {
+            await customRepo.putDocument("custom-doc-2", { x: 99 });
+            expect(await customRepo.getAttribute("custom-doc-2", "/x")).toBe(99);
+        });
+
+        it("deleteDocument works with custom key names", async () => {
+            await customRepo.putDocument("custom-doc-3", { y: "bye" });
+            await customRepo.deleteDocument("custom-doc-3");
+            expect(await customRepo.getDocument("custom-doc-3")).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
 ## Summary

   Adds a new `JsonPointerRepository<T>` class that stores JSON documents as individual DynamoDB items addressed by [JSON Pointer (RFC 
  6901)](https://datatracker.ietf.org/doc/html/rfc6901).

   Each leaf value of a document is stored as its own item with:
   - **Hash key**: `id` (document ID)
   - **Range key**: `pointer` (JSON Pointer path, e.g. `/address/city`)
   - **Attribute**: `value` (`string | number | boolean | null`)

