### PR TITLE
chore: bump vitest and @vitest/coverage-v8 from 4.1.6 to 4.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,14 +19,14 @@
         "@smithy/types": "^4.14.2",
         "@types/lodash": "^4.17.24",
         "@types/node": "^25.9.1",
-        "@vitest/coverage-v8": "^4.1.6",
+        "@vitest/coverage-v8": "^4.1.7",
         "eslint": "^10.4.0",
         "semantic-release": "^25.0.3",
         "testcontainers": "^12.0.0",
         "tsdown": "^0.22.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.4",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.7"
       },
       "peerDependencies": {
         "@aws-sdk/client-dynamodb": ">= 3.1050.0",
@@ -1495,9 +1495,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1515,9 +1512,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1535,9 +1529,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1555,9 +1546,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1575,9 +1563,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1595,9 +1580,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3044,14 +3026,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.7",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -3065,8 +3047,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.6",
-        "vitest": "4.1.6"
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -3085,16 +3067,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -3103,13 +3085,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.6",
+        "@vitest/spy": "4.1.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -3130,9 +3112,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3143,13 +3125,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.6",
+        "@vitest/utils": "4.1.7",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -3157,14 +3139,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -3173,9 +3155,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -3183,13 +3165,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
+        "@vitest/pretty-format": "4.1.7",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -6329,9 +6311,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6353,9 +6332,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6377,9 +6353,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6401,9 +6374,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11767,19 +11737,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -11807,12 +11777,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
     "@smithy/types": "^4.14.2",
     "@types/lodash": "^4.17.24",
     "@types/node": "^25.9.1",
-    "@vitest/coverage-v8": "^4.1.6",
+    "@vitest/coverage-v8": "^4.1.7",
     "eslint": "^10.4.0",
     "semantic-release": "^25.0.3",
     "testcontainers": "^12.0.0",
     "tsdown": "^0.22.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.7"
   },
   "peerDependencies": {
     "@aws-sdk/client-dynamodb": ">= 3.1050.0",


### PR DESCRIPTION
Patch bump for the test runner and coverage provider.

| Package | Before | After |
|---|---|---|
| `vitest` | `^4.1.6` | `^4.1.7` |
| `@vitest/coverage-v8` | `^4.1.6` | `^4.1.7` |

No breaking changes — patch release only.

Closes #51