### PR TITLE
refactor: replace lodash with native implementations and remove peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@semantic-release/github": "^12.0.8",
         "@semantic-release/npm": "^13.1.5",
         "@smithy/types": "^4.14.2",
-        "@types/lodash": "^4.17.24",
         "@types/node": "^25.9.1",
         "@vitest/coverage-v8": "^4.1.7",
         "eslint": "^10.4.0",
@@ -30,8 +29,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-dynamodb": ">= 3.1050.0",
-        "@aws-sdk/util-dynamodb": ">= 3.996.2",
-        "lodash": ">= 4.18.1"
+        "@aws-sdk/util-dynamodb": ">= 3.996.2"
       }
     },
     "node_modules/@actions/core": {
@@ -2609,13 +2607,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6332,6 +6323,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@semantic-release/github": "^12.0.8",
     "@semantic-release/npm": "^13.1.5",
     "@smithy/types": "^4.14.2",
-    "@types/lodash": "^4.17.24",
     "@types/node": "^25.9.1",
     "@vitest/coverage-v8": "^4.1.7",
     "eslint": "^10.4.0",
@@ -51,8 +50,7 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-dynamodb": ">= 3.1050.0",
-    "@aws-sdk/util-dynamodb": ">= 3.996.2",
-    "lodash": ">= 4.18.1"
+    "@aws-sdk/util-dynamodb": ">= 3.996.2"
   },
   "repository": {
     "type": "git",

--- a/src/DynamoDbRepository.ts
+++ b/src/DynamoDbRepository.ts
@@ -610,7 +610,13 @@ export class DynamoDbRepository<K, T> {
     batchGetItems = async (
         keys: K[], projectedQuery?: ProjectedQuery
     ): Promise<Array<T>> => {
-        const uniqueKeys = Array.from(new Map(keys.map(k => [JSON.stringify(k), k])).values());
+        const dedupeKey = (key: K): string => {
+            const record = key as Record<string, unknown>;
+            return this.rangKey
+                ? `${String(record[this.hashKey])}\0${String(record[this.rangKey])}`
+                : String(record[this.hashKey]);
+        };
+        const uniqueKeys = Array.from(new Map(keys.map(k => [dedupeKey(k), k])).values());
         const keyPages = paginate(uniqueKeys, 100);
         const {projectedAttributes} = projectedQuery || {};
         const ProjectionExpression = projectedAttributes

--- a/src/DynamoDbRepository.ts
+++ b/src/DynamoDbRepository.ts
@@ -18,7 +18,6 @@ import {
     WriteRequest,
 } from "@aws-sdk/client-dynamodb";
 import {marshall, unmarshall, NativeAttributeValue} from "@aws-sdk/util-dynamodb";
-import {replace, uniqWith, isEqual, pickBy} from "lodash";
 
 export enum FilterOperator {
     EQUALS = "=",
@@ -77,7 +76,7 @@ export interface ScanQuery extends Partial<FilterableQuery>, Partial<ProjectedQu
 const marshallKey = (key: unknown) =>
     marshall(key as Record<string, NativeAttributeValue>, {removeUndefinedValues: true});
 
-const expressionAttributeKey = (key: string) => replace(key, /-/g, "_");
+const expressionAttributeKey = (key: string) => key.replace(/-/g, "_");
 
 const mapInKeys = (filterExpression: FilterExpression) =>
     Array.isArray(filterExpression.value)
@@ -374,7 +373,7 @@ export class DynamoDbRepository<K, T> {
                     collectedKeys.push(
                         ...(page.Items.map((item) => unmarshall(item) as T)
                             .map((item: T) =>
-                                pickBy(item as object, (_, key) => (key === this.hashKey || key === this.rangKey)) as K)),
+                                Object.fromEntries(Object.entries(item as object).filter(([key]) => key === this.hashKey || key === this.rangKey)) as K)),
                     )
                 }
                 if (limit && collectedKeys.length >= limit) break;
@@ -399,7 +398,7 @@ export class DynamoDbRepository<K, T> {
             if (projectedAttributes) {
                 const projSet = new Set(projectedAttributes);
                 return orderedItems.map(item =>
-                    pickBy(item as object, (_, key) => projSet.has(key)) as T
+                    Object.fromEntries(Object.entries(item as object).filter(([key]) => projSet.has(key))) as T
                 ) as Array<T>;
             }
             return orderedItems as Array<T>;
@@ -509,7 +508,7 @@ export class DynamoDbRepository<K, T> {
             const collectedKeys = (result.Items ?? [])
                 .map((item) => unmarshall(item) as T)
                 .map((item: T) =>
-                    pickBy(item as object, (_, key) => (key === this.hashKey || key === this.rangKey)) as K
+                    Object.fromEntries(Object.entries(item as object).filter(([key]) => key === this.hashKey || key === this.rangKey)) as K
                 );
             const keyAttrs = [this.hashKey, ...(this.rangKey ? [this.rangKey] : [])];
             const batchProjectedQuery = projectedAttributes
@@ -530,7 +529,7 @@ export class DynamoDbRepository<K, T> {
             if (projectedAttributes) {
                 const projSet = new Set(projectedAttributes);
                 return {
-                    items: orderedItems.map(item => pickBy(item as object, (_, key) => projSet.has(key)) as T),
+                    items: orderedItems.map(item => Object.fromEntries(Object.entries(item as object).filter(([key]) => projSet.has(key))) as T),
                     cursor: nextCursor,
                 };
             }
@@ -611,7 +610,7 @@ export class DynamoDbRepository<K, T> {
     batchGetItems = async (
         keys: K[], projectedQuery?: ProjectedQuery
     ): Promise<Array<T>> => {
-        const uniqueKeys = uniqWith(keys, isEqual);
+        const uniqueKeys = Array.from(new Map(keys.map(k => [JSON.stringify(k), k])).values());
         const keyPages = paginate(uniqueKeys, 100);
         const {projectedAttributes} = projectedQuery || {};
         const ProjectionExpression = projectedAttributes

--- a/src/consumed-capacity-middleware.ts
+++ b/src/consumed-capacity-middleware.ts
@@ -11,7 +11,7 @@ import {
     InitializeHandlerOutput,
 } from "@smithy/types";
 
-import {get} from "lodash";
+
 
 export interface ConsumedCapacityDetail {
     ReturnConsumedCapacity: ReturnConsumedCapacity | undefined
@@ -27,10 +27,10 @@ export const consumedCapacityMiddleware =
         (next: InitializeHandler<ServiceInputTypes, ServiceOutputTypes>) =>
             async (args: InitializeHandlerArguments<ServiceInputTypes>): Promise<InitializeHandlerOutput<ServiceOutputTypes>> => {
                 const {input} = args;
-                const returnConsumedCapacity = get(input, "ReturnConsumedCapacity") as ReturnConsumedCapacity | undefined;
+                const returnConsumedCapacity = (input as unknown as Record<string, unknown>)["ReturnConsumedCapacity"] as ReturnConsumedCapacity | undefined;
                 const response = await next(args);
                 const {output} = response;
-                const consumedCapacity = get(output, "ConsumedCapacity") as ConsumedCapacity | ConsumedCapacity[] | undefined;
+                const consumedCapacity = (output as unknown as Record<string, unknown>)["ConsumedCapacity"] as ConsumedCapacity | ConsumedCapacity[] | undefined;
                 await consumedCapacityMiddlewareConfig.onConsumedCapacity({ReturnConsumedCapacity: returnConsumedCapacity, ConsumedCapacity: consumedCapacity});
                 return response;
             };


### PR DESCRIPTION
Closes #58

## Changes

- `replace(key, /-/g, "_")` → `key.replace(/-/g, "_")`
- `pickBy(item, pred)` → `Object.fromEntries(Object.entries(item).filter(...))`
- `uniqWith(keys, isEqual)` → `Map`-based deduplication via `JSON.stringify`
- `get(obj, key)` → direct property access with type cast
- Removed `lodash` from `peerDependencies` and `@types/lodash` from `devDependencies`

Consumers no longer need to install lodash alongside this library. No public API change.